### PR TITLE
Add minimal LLaMA chat web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # Web-GUI-for-KI
+
+This project provides a minimal web user interface for interacting with a LLaMA-based language model.
+
+## Installation
+
+Install the dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the application with:
+
+```bash
+python app.py
+```
+
+By default the script loads the `openlm-research/open_llama_3b` model from Hugging Face. You can specify a different model by setting the `MODEL_NAME` environment variable:
+
+```bash
+MODEL_NAME=meta-llama/Llama-2-7b-chat-hf python app.py
+```
+
+The web interface will start and provide a simple chat view similar to ChatGPT.
+
+## Notes
+
+Running large models such as Llama 2 may require a GPU with sufficient memory. You can start with a smaller model if you encounter resource issues.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+import os
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import gradio as gr
+
+
+def load_model():
+    model_name = os.getenv("MODEL_NAME", "openlm-research/open_llama_3b")
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16 if torch.cuda.is_available() else torch.float32)
+    model.to('cuda' if torch.cuda.is_available() else 'cpu')
+    return model, tokenizer
+
+model, tokenizer = load_model()
+
+
+def generate_response(message, history):
+    conversation = ""
+    for user_msg, bot_msg in history:
+        conversation += f"<s>[INST] {user_msg} [/INST] {bot_msg}</s> "
+    conversation += f"<s>[INST] {message} [/INST]"
+    inputs = tokenizer(conversation, return_tensors="pt").to(model.device)
+    outputs = model.generate(**inputs, max_new_tokens=200, do_sample=True, top_p=0.9)
+    response = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    # only return newly generated text after last prompt
+    response = response.split("[/INST]")[-1].strip()
+    history.append((message, response))
+    return response
+
+iface = gr.ChatInterface(fn=generate_response, title="LLaMA Chat", description="A simple web interface for chatting with a LLaMA model.")
+
+if __name__ == "__main__":
+    iface.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+transformers
+torch
+accelerate
+peft
+sentencepiece
+scipy
+gradio


### PR DESCRIPTION
## Summary
- add a simple Gradio app using HuggingFace LLaMA models
- document how to install dependencies and run the web UI
- include required packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fc7de68c832cb64e0e53ed2d63c4